### PR TITLE
Correct spelling/grammar in tutorial 03

### DIFF
--- a/notes/03_mlp-backprop/grad_descent.tex
+++ b/notes/03_mlp-backprop/grad_descent.tex
@@ -28,7 +28,7 @@
 
 \end{frame}
 
-\subsection{Finding the minumum of the training error analytically}
+\subsection{Finding the minimum of the training error analytically}
 
 \begin{frame}\frametitle{\subsecname}
 
@@ -71,7 +71,7 @@
 
 \mode<article>{
 
-Learning from gradient descent is an alternate approach for finding the minimum of a function, when the closed-form solution is not available.
+Learning from gradient descent is an alternate approach for finding the minimum of a function when the closed-form solution is not available.
 
 }
     \begin{figure}[h]
@@ -339,6 +339,6 @@ Learning from gradient descent is an alternate approach for finding the minimum 
     \end{figure}
     
     \eqref{eq:gradient_descent_mlp} shows us how gradients are used for iteratively finding the minimum of the training error.
-    The layered structure of an MLP implies that computing the gradient requires a more involved application of the chain rule. The backpropagation algorithm exploits the chain rule to efficently compute the gradients for an MLP.
+    The layered structure of an MLP implies that computing the gradient requires a more involved application of the chain rule. The backpropagation algorithm exploits the chain rule to efficiently compute the gradients for an MLP.
     }
     

--- a/notes/03_mlp-backprop/mlp_backprop.tex
+++ b/notes/03_mlp-backprop/mlp_backprop.tex
@@ -103,7 +103,7 @@ The Backpropagation algorithm handles the computation of the term in \eqref{eq:m
     \begin{enumerate}
      \item The contribution of $h^{v'}_{i}$ to the network's response $y(\vec x; \vec w)$. This is referred to as the ``local error'' at neuron $(v',i)$. The efficiency of the Backpropagation algorithm is based on how it computes the ``local error'' denoted by $\delta_i^{v'}$ for neuron $(v', i)$ and all other neurons in the network.
      \item The contribution of $h^{v'}_{i}$ due to one of its inputs, namely neuron $(v,j)$ which is weighted by $w_{ij}^{v'v}$. We already have everything to compute this term and that is by taking the definition of $h^{v'}_{i}$ in \eqref{eq:total_input_vi} and taking the derivative w.r.t. $w_{ij}^{v'v}$. 
-     This should be straightforward, since only a single term in the sum depends on $w_{ij}^{v'v}$:
+     This should be straightforward since only a single term in the sum depends on $w_{ij}^{v'v}$:
          \begin{equation}
             \frac{{\color{darkgreen}\partial h_i^{v'}}}
             {\partial w_{ij}^{v'v}}
@@ -131,12 +131,12 @@ The Backpropagation algorithm handles the computation of the term in \eqref{eq:m
     \begin{enumerate}
      \item \textbf{forward propagation} (forward pass)
      \mode<article>{: Given some input $\vec x$, compute the activities of all neurons and the response of the network.}
-     \item \textbf{backwards propagation} (backward pass)
-     \mode<article>{: Given the response of the network, recursively calculate the local errors starting with the output node and work your way backwards through the network.}
+     \item \textbf{backward propagation} (backward pass)
+     \mode<article>{: Given the response of the network, recursively calculate the local errors starting with the output node and work your way backward through the network.}
     \end{enumerate}
 \end{frame}
 
-\subsection{Forward and backwards propagation}
+\subsection{Forward and backward propagation}
 
 % -----------------------------------------------------------------------------
 \begin{frame} \frametitle{The Backpropagation algorithm}


### PR DESCRIPTION
Fixed spelling mistakes and aligned usage of forward/backward [AE] (vs. forwards/backwards [BE]).