### PR TITLE
Correct spelling/grammar in tutorial 10

### DIFF
--- a/notes/10_svm/2_margin.tex
+++ b/notes/10_svm/2_margin.tex
@@ -15,7 +15,7 @@
 
 \begin{frame}\frametitle{\subsecname}
 \mode<article>{
-Consider the following linearly separable binary classification problem and the different hyperplanes for separating the two classes. In order to identify the margn of a hyperplane:
+Consider the following linearly separable binary classification problem and the different hyperplanes for separating the two classes. In order to identify the margin of a hyperplane:
 }
 
 \only<1-3>{
@@ -150,7 +150,7 @@ Remember: We are only dealing with a linearly separable problem.
 
 \newpage
 
-\subsection{Margins and the VC-dimension}
+\subsection{Margins and the VC dimension}
 
 \begin{frame}
 
@@ -170,7 +170,7 @@ Remember: We are only dealing with a linearly separable problem.
     \includegraphics[height=4cm]{img/dvc_margin1_balloon} 
     \mode<article>{
     \caption{
-    The general setting assumed for deriving the upper bound on the VC-dimension of the maximum margin classifier.
+    The general setting assumed for deriving the upper bound on the VC dimension of the maximum margin classifier.
     }
     \label{fig:dvcmarginboundsetting}
     } 
@@ -207,7 +207,7 @@ where,\\
 
 \mode<article>{
 
-The bound in \eqref{eq:dvcmarginbound} assumes a setting as depicted by \figref{fig:dvcmarginboundsetting}. It tells us that, if we draw a sphere around our training data with radius $\mathrm{d}_{R}$ and a second sphere inside of it using the margin $\mathrm{d}_{w}$ as its radius, knowing that the inner sphere is placed in the center and does not contain any datapoints, the theorem then tells us that the VC-dimension is no longer $N+1$ but only as big as the integer component
+The bound in \eqref{eq:dvcmarginbound} assumes a setting as depicted by \figref{fig:dvcmarginboundsetting}. It tells us that, if we draw a sphere around our training data with radius $\mathrm{d}_{R}$ and a second sphere inside of it using the margin $\mathrm{d}_{w}$ as its radius, knowing that the inner sphere is placed in the center and does not contain any datapoints, the theorem then tells us that the VC dimension is no longer $N+1$ but only as big as the integer component
 \footnote{If interested in a proof for \textit{Theorem 10.3}, see 
 \href{http://web.eecs.umich.edu/\~jabernet/eecs598course/fall2015/web/notes/lec11\_101315.pdf}
 {http://web.eecs.umich.edu/\~jabernet/eecs598course/fall2015/web/notes/lec11\_101315.pdf}
@@ -265,7 +265,7 @@ Recall the definition of the $\dvc$ as the \underline{maximal number of training
          }
      \end{subfigure}
      \mode<article>{
-     \caption{A linear neuron can shatter any label configuration of 3 points regardless of how they are arranged in 2D space (excluding colinear points).}
+     \caption{A linear neuron can shatter any label configuration of 3 points regardless of how they are arranged in 2D space (excluding collinear points).}
 	 }
 	 \label{fig:shatter3pts}
 \end{figure}
@@ -278,7 +278,7 @@ As the margin increases, i.e. $\mathrm{d}_{w}\,\rightarrow\,\mathrm{d}_{R}$\note
 $$
 \dvc\;\rightarrow\;2
 $$}
-In the case of $\mathrm{d}_{w} = \mathrm{d}_{R}$\notesonly{ the VC-dimension will be reducedto 1. But since this implies a dataset of only a single point, it is not such an interesting case.}
+In the case of $\mathrm{d}_{w} = \mathrm{d}_{R}$\notesonly{ the VC dimension will be reduced to 1. But since this implies a dataset of only a single point, it is not such an interesting case.}
 \slidesonly{
 $$
 \dvc\;\rightarrow\;1
@@ -421,7 +421,7 @@ only depends on $p$ and $\dvc$.}}
     \includegraphics[height=3.5cm]{img/section2_fig12_v2} 
     \mode<article>{
     \caption{
-    The effect of the VC-dimension and bias-variance trade-off
+    The effect of the VC dimension and bias-variance trade-off
     }
     \label{fig:dvcbiasvariance}
     } 

--- a/notes/10_svm/3_svm.tex
+++ b/notes/10_svm/3_svm.tex
@@ -135,7 +135,7 @@ The cost function\notesonly{ to minimize}:
 \frac{1}{2} \vec w^{\top} \vec w = \frac{1}{2} \lVert \vec w \rVert_{2}^{2} \eqexcl \min    
 \end{equation}
 
-\question{Why have we suddenly switched to the squared Euclidean norm and where did the 2 come form?}
+\question{Why have we suddenly switched to the squared Euclidean norm and where did the 2 come from?}
 
 \mode<article>{
 - Minimizing the square of the norm turns it into a \emph{convex} minimization problem, which simplifies the optimization procedure.
@@ -144,7 +144,7 @@ Dividing by 2 is simply for convenience.
 
 
 \notesonly{
-We want to restrict the space of solutions for $\vec w$ to that which leads to correct classification of the training points.
+We want to restrict the space of solutions for $\vec w$ to that which leads to the correct classification of the training points.
 We therefore constrain solutions such that:}
 
 \slidesonly{Constraint for correct classification (``\emph{0-1 loss}'' or ``\emph{hinge loss}''):}
@@ -159,7 +159,7 @@ We therefore constrain solutions such that:}
 \notesonly{
 \eqref{eq:constraint} provides constraints that are linear in $\vec w$. It is sometimes referred to as the \emph{0-1 loss} or \emph{hinge loss}. It is exactly zero whenever a point is correctly classified and 1 whenever it is misclassified. It behaves similarly to \emph{parity-check} with the difference that \emph{parity-check} only produces a binary output.
 
-This gives us the \emph{primal} problem for structural risk minimization (SRM) prooblem. }
+This gives us the \emph{primal} problem for structural risk minimization (SRM) problem. }
 \slidesonly{The SRM principle is about:}
 
 
@@ -289,7 +289,7 @@ This, along with the minimization being \emph{convex} and the constraints being 
 
 \mode<article>{
 - We will attempt to answer this by looking at the constraints and how different cases for the constraints affect the Lagrangian and in turn the variables we are optimizing.
-This will leads us to the identifying the Karush-Kuhn-Tucker (KKT) conditions.
+This will leads us to identifying the Karush-Kuhn-Tucker (KKT) conditions.
 }
 
 \end{frame}
@@ -757,9 +757,9 @@ Which is met with \textcolor{red}{equality} by any of the \textcolor{red}{suppor
         \big)\slidesonly{\qquad}
 \end{equation}
 
-\question{Why does the inner sum run through the SV's only?}
+\question{Why does the inner sum run through the SVs only?}
 
-- Indeed, $\vec w^{*}$ is in expansion of the weight vector in terms of all data points (cf. \eqref{eq:primalsolution1}). However, any point that is \textbf{not} a support vector is associated with a $\lambda$ that is equal to zero. Non-zero $\lambda$'s are only associated with support vectors. Therefore, the sum can be reduced to iterate over the non-zero $\lambda$'s only, which are those associated with the support vectors.
+- Indeed, $\vec w^{*}$ is an expansion of the weight vector in terms of all data points (cf. \eqref{eq:primalsolution1}). However, any point that is \textbf{not} a support vector is associated with a $\lambda$ that is equal to zero. Non-zero $\lambda$'s are only associated with support vectors. Therefore, the sum can be reduced to iterate over the non-zero $\lambda$'s only, which are those associated with the support vectors.
 
 \end{frame}
 

--- a/notes/10_svm/3_svm_csvm.tex
+++ b/notes/10_svm/3_svm_csvm.tex
@@ -57,7 +57,7 @@
 
 The margin we were constructing for the SVM so far is considered a ``hard'' in that it prohibits:
 \begin{enumerate}
-\item miasclassification error, points falling on the \emph{wrong} side of the decision boundary,\\
+\item misclassification error, points falling on the \emph{wrong} side of the decision boundary,\\
 
 and
 
@@ -243,7 +243,7 @@ The data point falls on the \emph{wrong} side of the decision boundary. Whether 
 	}
 	
 	\mode<article>{
-	Adding The second term to the minimization objective in \eqref{eq:csvmmin} avoids finding the trivial solution where the constrained can be satisifed by making any the slack variable of any point arbitrarily large.
+	Adding The second term to the minimization objective in \eqref{eq:csvmmin} avoids finding the trivial solution where the constrained can be satisfied by making any the slack variable of any point arbitrarily large.
 	}
 	
 	\only<4>{

--- a/notes/10_svm/3_svm_kernel.tex
+++ b/notes/10_svm/3_svm_kernel.tex
@@ -32,7 +32,7 @@ The feature space is transformed into a new space in which the classes can becom
 						\substack{ \text{monomials of}\\ \text{degree $n$}}}
 			\end{equation}
 \notesonly{
-However, instead of computing the transformation $\vec \phi$ explicitly (possible very costly in terms of memory footprint if the space of $\vec \phi$ has a very high dimensionality), we exploit the fact that }SVMs only ever operate with the scalar product. This is evident from the Lagrangian of the dual problem we use to construct the SVM:
+However, instead of computing the transformation $\vec \phi$ explicitly (possibly very costly in terms of memory footprint if the space of $\vec \phi$ has a very high dimensionality), we exploit the fact that }SVMs only ever operate with the scalar product. This is evident from the Lagrangian of the dual problem we use to construct the SVM:
 
 \begin{equation} 
     L(\{\lambda_\alpha\})
@@ -148,7 +148,7 @@ The Lagrangian of the dual problem for transformed features involves computing $
 
 \notesonly{
 - Constructing the matrix has the advantage of parallelizing applying the kernel on all the different pairs to speed up computation.
-However, it requires storage of a $p \times p$ values, which could be costly if the number of training points $p$ is very large.
+However, it requires the storage of $p \times p$ values, which could be costly if the number of training points $p$ is very large.
 }
 
 \end{frame}


### PR DESCRIPTION
Fix typos and consistently use "VC dimension" instead of mix with "VC-dimension".