### PR TITLE
Correct spelling in tutorial 12

### DIFF
--- a/notes/12_inference_bayesian-nets/1_inference.tex
+++ b/notes/12_inference_bayesian-nets/1_inference.tex
@@ -90,7 +90,7 @@ Because we need to
 
 \begin{frame}
 
-$\underbrace{\text{\emph{Summing over}}}_{\text{marginalisation}}$ the probabilities of the \textbf{events} \\
+$\underbrace{\text{\emph{Summing over}}}_{\text{marginalization}}$ the probabilities of the \textbf{events} \\
 $\slidesonly{\qquad\qquad\qquad}\leadsto$ probability of \textbf{proposition}.\\
 
 \pause
@@ -238,7 +238,7 @@ Example of a full joint distribution between $\mathit{Cavity},Toothache$ and $\m
 
 \end{frame}
 
-\subsubsection{Marginalisation (``summing out'')}
+\subsubsection{Marginalization (``summing out'')}
 
 
 

--- a/notes/12_inference_bayesian-nets/2_bayes.tex
+++ b/notes/12_inference_bayesian-nets/2_bayes.tex
@@ -156,7 +156,7 @@ P(\mathit{Cavity}|\mathit{toothache}=\text{true}, \mathit{catch}=\text{true}) &\
 \label{eq:applybayes}
 \end{align}
 
-$\circledast$ similar scaling problem, not much better then the case of using the full joint distribution.
+$\circledast$ similar scaling problem, not much better than the case of using the full joint distribution.
 
 }
 


### PR DESCRIPTION
Fix typos and use marginalization (AE) consistent with other AE spelling (e.g. normalization).