### PR TITLE
correct spelling in gradient descent

### DIFF
--- a/notes/03_mlp-backprop/grad_descent.tex
+++ b/notes/03_mlp-backprop/grad_descent.tex
@@ -77,7 +77,7 @@ Learning from gradient descent is an alternate approach for finding the minimum 
     \begin{figure}[h]
         \centering
         \includegraphics[height=3.cm]{img/section1_fig19}
-        \caption{Minimzing the training error iteratively via gradient descent}
+        \caption{Minimizing the training error iteratively via gradient descent}
         \label{fig:minimize_via_gradient_descent} 
     \end{figure}
     
@@ -100,8 +100,8 @@ Learning from gradient descent is an alternate approach for finding the minimum 
     
     with $j=0,\ldots,N$
     \mode<article>{
-    $\vec w^{\mathrm{init}}$ is bascially a random guess of where the solution might be and going against the gradient will potentially move us closer to the minimum. 
-    }
+    $\vec w^{\mathrm{init}}$ is basically a random guess of where the solution might be and going against the gradient will potentially move us closer to the minimum. 
+    }b
     }
 	\only<2,3>{
     For an MLP:


### PR DESCRIPTION
disregard this one, added a stray 'b'