### PR TITLE
Fixed wrong index of perceptron

### DIFF
--- a/notes/02_perceptron/1_perceptron-limitations.tex
+++ b/notes/02_perceptron/1_perceptron-limitations.tex
@@ -186,7 +186,7 @@ A third perceptron ${\color{blue}s^2_1}$ will then use the responses of both and
 \mode<article>{
 
 
-What we are essentially describing is a Multilayered perceptron (MLP) with an architecture as illustrated in \figref{fig:xor_mlp_arch}. This MLP is made up of an output layer with a single output neuron ${\color{blue}s^2_1}$, and one hidden layer with two hidden neurons, ${\color{magenta}s^1_1}$ and ${\color{green}s^2_2}$ (the superscript denotes the layer index, the subscript denotes the neuron index within its layer). The terms ``neurons'' and ``nodes'' are treated as synonyms.
+What we are essentially describing is a Multilayered perceptron (MLP) with an architecture as illustrated in \figref{fig:xor_mlp_arch}. This MLP is made up of an output layer with a single output neuron ${\color{blue}s^2_1}$, and one hidden layer with two hidden neurons, ${\color{magenta}s^1_1}$ and ${\color{green}s^1_2}$ (the superscript denotes the layer index, the subscript denotes the neuron index within its layer). The terms ``neurons'' and ``nodes'' are treated as synonyms.
 }
 \begin{frame}
 


### PR DESCRIPTION
I know this is really minor and not really worth the hassle, but I found a typo in the perceptron notes.