### PR TITLE
SLT fixes in notes

### DIFF
--- a/notes/09_slt/1_risk.tex
+++ b/notes/09_slt/1_risk.tex
@@ -13,6 +13,7 @@
     \begin{center}
 		\includegraphics[height=4cm]{img/section2_fig1_highlight}
 		\captionof{figure}{Comparing risk with empirical risk using a finite set with $p$ points.}
+        \label{fig:riskvsemprisk}
 	\end{center}
     }
     \mode<presentation>{
@@ -114,7 +115,7 @@
 \end{frame}
 	
 \mode<article>{			
-			Understanding \figref{fig:randremp} and
+			Understanding \figref{fig:riskvsemprisk} and
 			what \eqref{eq:absdeltaconvergence0} represents:
 				
 			\begin{itemize}
@@ -139,7 +140,7 @@
 						\big|R_{(\vec w_p)} - R_{(\vec w_0)}\big| 
 					}
 				\geq \eta \big\}$
-			\item We measure the probability of the absolute difference exceeding some value $\eta$:
+			\item We measure the probability of the absolute difference being equal or exceeding some nonnegative value $\eta$:
 			\begin{equation}
 			P\big\{ 
 					{\color{question1}
@@ -147,36 +148,56 @@
 					}
 				\geq \eta \big\}\,, \quad \forall \eta > 0
 			\end{equation}
-			This is the same asking: How often does training with $p$ points yield a difference in risk above some value.
+			This is the same as asking: How often does training with $p$ points yield a difference in risk above some value.
 			\item Now we repeat the training of these models but using a larger value for $p$.\\
 			
-			What the theory tells you is that as you increase $p$ and keeping $\eta$ fixed:
+			What the theory tells you here is that as you increase $p$ and keeping $\eta$ fixed:
 			\begin{itemize}
 				\item The $R_{(\vec w_p)}$ of the models will improve and get smaller.
-				\item The absolute differences ${color{question1}\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big|}$ will become smaller and smaller,
-				\item As depicted by \figref{fig:PdeltaReta}, the distribution of these differences will shift below $\eta$ (i.e. to the left of $\eta$)
+				\item The absolute differences ${\color{question1}\big|R_{(\vec w_p)} - R_{(\vec w_0)}\big|}$ will become smaller and smaller,
+				\item As depicted by \figref{fig:PdeltaReta}, the distribution of these differences will shift to the left of $\eta$.
 				\item Less and less models will score differences $\ge \eta$
-				\item Eventually, for some large $p$, the $R_{(\vec w_p)}$ of the models will be so good that the probability of finding a model that has a risk difference of $\eta$ or higher (worse performance) will vanish. And this is what \eqref{eq:risktozero} describes:
+				\item Eventually, for some large $p$, the $R_{(\vec w_p)}$ of the models will be so good that the probability of finding a model that has a risk difference of $\eta$ or higher (worse performance) will vanish. And this is what \eqref{eq:absdeltaconvergence0} describes.
 			\end{itemize}
 			\end{itemize}
-			\begin{equation}
-				\lim_{p \to \infty} P\bigg\{ 
-					{\color{question1}
-						\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big| 
-					}
-				\geq \eta \bigg\}\;\;=\;\; 0 \,, \quad \forall \eta > 0
-				\label{eq:risktozero}
-			\end{equation}
+			%\begin{equation}
+				%\lim_{p \to \infty} P\bigg\{ 
+					%{\color{question1}
+						%\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big| 
+					%}
+				%\geq \eta \bigg\}\;\;=\;\; 0 \,, \quad \forall \eta > 0
+				%\label{eq:risktozero}
+			%\end{equation}
 			
-			\textbf{But} Our dataset is never going to be infinitely large. Therefore a more realistic formulation for the convergence of ERM would be that it will below some value $\epsilon$:
-			\begin{equation}
+			\textbf{But} Our dataset is never going to be infinitely large. Therefore a more realistic formulation for the convergence of ERM would be that the probability will fall below some value $\epsilon$ which gives rise to the next key question from Statistical Learning Theory:
+            
+            \begin{enumerate}
+            \item[2] How strongly does $R_{(\vec{w}_p)}$ differ 
+				from $R_{(\vec{w}_0)}$ for  \textbf{finite} samples?
+				\vspace{1mm}
+				\iitem{For a given confidence $\epsilon$, find $\eta$ such that}
+				\vspace{1mm}
+                
+                \begin{equation}
 					P \Big\{ {\color{question1} 
 							\big| R_{(\vec{w}_p)} - R_{(\vec{w}_0)} \big| 
 						} \geq \eta \Big\} \;\;<\;\; \epsilon \,.
 						\label{eq:convergenceeps}
 				\end{equation}
+            \end{enumerate}
+            
 				
-			Furthermore, recalling what we've learned about the bias-variance tradeoff, the solution that minimizes $R_{\text{emp}}$ might not be a favorable solution. We therefore extend comparison of the curves $R_{\text{emp}}$ with $R$ to include other solutions that do not necessarily minimize the empirical risk $R_{\text{emp}}$ (i.e. training error). This leads to further modifying our formulation of the convergence from \eqref{eq:convergenceeps} to:
+			Furthermore, recalling what we've learned about the bias-variance tradeoff, the solution that minimizes $R_{\text{emp}}$ might not be a favorable solution. We therefore extend the comparison of the curves $R_{\text{emp}}$ with $R$ to include other solutions that do not necessarily minimize the empirical risk $R_{\text{emp}}$ (i.e. training error). This leads to further modifying our formulation of the convergence from \eqref{eq:convergenceeps} in order to formulate the next key question from Statistical Learning Theory:
+            
+            \begin{enumerate}
+            \item[3] Do training errors $R_{\text{emp}(\vec w)}$ 
+				reflect generalization performance $R_{(\vec w)}$?
+				\vspace{1mm}
+				\iitem{\footnotesize Avoid overfitting for finite samples,
+				i.e.~given confidence $\epsilon$, find $\eta$ such that: 
+					%i.e.~$R_{(\vec w)} \approx R_{\mathrm{emp}(\vec w)}$:
+				}
+                
 				\begin{equation}
 					P \Big\{ {\color{question2}
 							\big| R_{(\vec w)} - R_{\mathrm{emp}(\vec w)} \big|
@@ -184,10 +205,12 @@
 						\qquad \forall \vec w \in \Lambda \,.
 						\label{eq:convergenceepsgeneral}
 				\end{equation}
+            \end{enumerate}
 			
 			The key difference between \eqref{eq:convergenceeps} and \eqref{eq:convergenceepsgeneral} is that the latter is no longer restricted to the solutions $\vec w_p$ at which the empirical risk is minimal but may include solutions $\vec w$ that can potentially generalize better.
 }
-
+\mode<presentation>
+{
 \begin{frame}\frametitle{\subsecname}
 	\begin{center} 
 	\slidesonly{
@@ -215,7 +238,7 @@
 					P \Big\{ {\color{question1} 
 							\big| R_{(\vec{w}_p)} - R_{(\vec{w}_0)} \big| 
 						} \geq \eta \Big\} \;\;<\;\; \epsilon \,.
-						\label{eq:convergenceeps}
+						%\label{eq:convergenceeps}
 				\end{equation}
 		\end{enumerate}
 	} \only<2>{
@@ -233,9 +256,10 @@
 							\big| R_{(\vec w)} - R_{\mathrm{emp}(\vec w)} \big|
 						} > \eta \Big\} \;\;<\;\; \epsilon \,, 
 						\qquad \forall \vec w \in \Lambda \,.
-						\label{eq:convergenceepsgeneral}
+						%\label{eq:convergenceepsgeneral}
 				\end{equation}
                 where $\Lambda$ is the model class (e.g. connectionist neuron)
 		\end{enumerate}
 	}
 \end{frame}
+}

--- a/notes/09_slt/1_risk.tex
+++ b/notes/09_slt/1_risk.tex
@@ -115,18 +115,18 @@
 	
 \mode<article>{			
 			Understanding \figref{fig:randremp} and
-			what\eqref{eq:absdeltaconvergence0} represents:
+			what \eqref{eq:absdeltaconvergence0} represents:
 				
 			\begin{itemize}
-			\item We expect the model trained on $p$ points to have  some error $R_{\text{emp}}$ that is minimal for some $\vec w_p$ at which the empirical error is $R_{\text{emp}[\vec w_p]}$.
-			\item Estimating the generalization performance for the solution $\vec w_p$ on a hold-out set yields a risk value of $R_{[\vec w_p]}$. We expect it to be higher than the optimal risk $R_{[\vec w_0]}$. We therefore measure the absolute difference between both:
+			\item We expect the model trained on $p$ points to have  some error $R_{\text{emp}}$ that is minimal for some $\vec w_p$ at which the empirical error is $R_{\text{emp}(\vec w_p)}$.
+			\item Estimating the generalization performance for the solution $\vec w_p$ on a hold-out set yields a risk value of $R_{(\vec w_p)}$. We expect it to be higher than the optimal risk $R_{(\vec w_0)}$. We therefore measure the absolute difference between both:
 			\begin{equation}
 			{\color{question1}
 			\big| R_{(\vec{w}_p)}
 						- R_{(\vec{w}_0)} \big|
 						}
 			\end{equation}
-			\item Training the model with a different set of $p$ points (the size of the training set is kept at $p$) may yield a different minimum for $R_{\text{emp}[\vec w_p]}$ with a corresponding generalization performance $R_{[\vec w_p]}$ and consequently a different absolute difference ${\color{question1}
+			\item Training the model with a different set of $p$ points (the size of the training set is kept at $p$) may yield a different minimum for $R_{\text{emp}(\vec w_p)}$ with a corresponding generalization performance $R_{(\vec w_p)}$ and consequently a different absolute difference ${\color{question1}
 			\big| R_{(\vec{w}_p)}
 						- R_{(\vec{w}_0)} \big|
 						}$
@@ -134,16 +134,16 @@
 			\big| R_{(\vec{w}_p)}
 						- R_{(\vec{w}_0)} \big|
 						}$
-			\item Measuring the absolute difference between every $R_{[\vec w_p]}$ we obtained and $R_{[\vec w_0]}$ will lead to ``difference values'' that follow some distribution $P\big\{ 
+			\item Measuring the absolute difference between every $R_{(\vec w_p)}$ we obtained and $R_{(\vec w_0)}$ will lead to ``difference values'' that follow some distribution $P\big\{ 
 					{\color{question1}
-						\big|R_{[\vec w_p]} - R_{[\vec w_0]}\big| 
+						\big|R_{(\vec w_p)} - R_{(\vec w_0)}\big| 
 					}
 				\geq \eta \big\}$
 			\item We measure the probability of the absolute difference exceeding some value $\eta$:
 			\begin{equation}
 			P\big\{ 
 					{\color{question1}
-						\big|R_{[\vec w_p]} - R_{[\vec w_0]}\big| 
+						\big|R_{(\vec w_p)} - R_{(\vec w_0)}\big| 
 					}
 				\geq \eta \big\}\,, \quad \forall \eta > 0
 			\end{equation}
@@ -152,11 +152,11 @@
 			
 			What the theory tells you is that as you increase $p$ and keeping $\eta$ fixed:
 			\begin{itemize}
-				\item The $R_{[\vec w_p]}$ of the models will improve and get smaller.
-				\item The absolute differences ${color{question1}\Big|R_{[\vec w_p]} - R_{[\vec w_0]}\Big|}$ will become smaller and smaller,
+				\item The $R_{(\vec w_p)}$ of the models will improve and get smaller.
+				\item The absolute differences ${color{question1}\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big|}$ will become smaller and smaller,
 				\item As depicted by \figref{fig:PdeltaReta}, the distribution of these differences will shift below $\eta$ (i.e. to the left of $\eta$)
 				\item Less and less models will score differences $\ge \eta$
-				\item Eventually, for some large $p$, the $R_{[\vec w_p]}$ of the models will be so good that the probability of finding a model that has a risk difference of $\eta$ or higher (worse performance) will vanish. And this is what \eqref{eq:risktozero} describes:
+				\item Eventually, for some large $p$, the $R_{(\vec w_p)}$ of the models will be so good that the probability of finding a model that has a risk difference of $\eta$ or higher (worse performance) will vanish. And this is what \eqref{eq:risktozero} describes:
 			\end{itemize}
 			\end{itemize}
 			\begin{equation}
@@ -171,7 +171,7 @@
 			\textbf{But} Our dataset is never going to be infinitely large. Therefore a more realistic formulation for the convergence of ERM would be that it will below some value $\epsilon$:
 			\begin{equation}
 					P \Big\{ {\color{question1} 
-							\big| R_{[\vec{w}_p]} - R_{[\vec{w}_0]} \big| 
+							\big| R_{(\vec{w}_p)} - R_{(\vec{w}_0)} \big| 
 						} \geq \eta \Big\} \;\;<\;\; \epsilon \,.
 						\label{eq:convergenceeps}
 				\end{equation}
@@ -179,7 +179,7 @@
 			Furthermore, recalling what we've learned about the bias-variance tradeoff, the solution that minimizes $R_{\text{emp}}$ might not be a favorable solution. We therefore extend comparison of the curves $R_{\text{emp}}$ with $R$ to include other solutions that do not necessarily minimize the empirical risk $R_{\text{emp}}$ (i.e. training error). This leads to further modifying our formulation of the convergence from \eqref{eq:convergenceeps} to:
 				\begin{equation}
 					P \Big\{ {\color{question2}
-							\big| R_{[\vec w]} - R_{\mathrm{emp}[\vec w]} \big|
+							\big| R_{(\vec w)} - R_{\mathrm{emp}(\vec w)} \big|
 						} > \eta \Big\} \;\;<\;\; \epsilon \,, 
 						\qquad \forall \vec w \in \Lambda \,.
 						\label{eq:convergenceepsgeneral}

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -282,7 +282,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 			\label{eq:growthpiecewise}
 			\end{equation}
 
-		\item Vapnik-Chernovenkis dimension $d_{VC}$: \\
+		\item Vapnik-Chernovenkis dimension $\dvc$: \\
 			capacity measure of the model class
 		%\itR the growth function is independent of a specific sample
 		%\itR the growth function is bounded by a term logarithmic in $p$
@@ -296,9 +296,9 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 		\includegraphics[height=5.7cm]{img/growth_function_clean}
 	\end{center}
 	\vspace{-2mm}
-	$d_{VC}$: capacity measure of the model class\\
-	small $d_{VC}$: small sample size sufficient for learning\\
-	large $d_{VC}$: large sample size required
+	$\dvc$: capacity measure of the model class\\
+	small $\dvc$: small sample size sufficient for learning\\
+	large $\dvc$: large sample size required
 
 		%\item growth function defines VC-dimension $\dvc$
 		%\item higher capacity $\rightarrow$ more different labelings

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -332,7 +332,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 			
 			\begin{equation}
 				\lim_{p \to \infty} P\bigg\{ 
-					{
+					{\color{blue}
 						\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big| 
 					}
 				\geq \eta \bigg\}\;\;=\;\; 0 \,, \quad \forall \eta > 0
@@ -344,7 +344,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 			
 			\begin{equation}
 				\lim_{p \to \infty} P\bigg\{ 
-					{
+					{\color{blue}
 						\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big| 
 					}
 				\geq \eta \bigg\}\;\;<\;\; \epsilon \,, \quad \forall \eta > 0

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -259,7 +259,7 @@ It is closely related to the \emph{VC dimension}.
 \begin{frame}
 However, for $p > \dvc$ the growth function behaves differently, namely
 	\begin{equation}
-		G^{\Lambda}_{(p)} \le \dvc \cdot \big(1+ ln \frac{p}{\dvc}\big)
+		G^{\Lambda}_{(p)} \le \dvc \cdot \Big(1+ ln \frac{p}{\dvc}\Big)
 	\end{equation}
 	
 	In this case  $\lim_{p \to \infty} G_{(p)}^\Lambda$ converges to zero, and there is no more complete ambiguity. There is at least one region in feature space where all different classifiers from $\Lambda$ will agree on what class to assign to points in that region. There may still exist regions for which predictions will be ambiguous but the complete ambiguity is gone. The more points we add, the less likely a model will find a solution, but if it does, they will no longer be ambiguous.
@@ -276,7 +276,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 				\left \{ \begin{array}{ll}
 					= p \ln 2 
 					& \text{for } p \leq \dvc \\
-					\leq \dvc \Big( 1 + \ln \frac{p}{\dvc} \Big) 
+					\leq \dvc \cdot \Big( 1 + \ln \frac{p}{\dvc} \Big) 
 					& \text{for } p > \dvc
 				\end{array} \right.
 			\label{eq:growthpiecewise}

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -348,7 +348,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 						\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big| 
 					}
 				\geq \eta \bigg\}\;\;<\;\; \epsilon \,, \quad \forall \eta > 0
-				\label{eq:risktozero}
+				%\label{eq:risktozero}
 			\end{equation}
 			
 			The takeaway from the growth function and the bounds is that it defines the value of $\eta$ in \eqref{eq:convergenceeps} that can be targeted when training a specific model with a finite set of $p$ points.

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -340,7 +340,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 			\end{equation}
 			
 			\textbf{But} Our dataset is never going to be infinitely large. Therefore, a more realistic formulation would be that ERM converges to some small $\epsilon$.\\
-			We therefore reiterate \eqref{eq:convergenceeps}:
+			We therefore reformulate the above to:
 			
 			\begin{equation}
 				\lim_{p \to \infty} P\bigg\{ 
@@ -451,7 +451,7 @@ generalization capabilities of the model class which leads us to the following f
 			\vspace{-2mm}
 			\begin{equation}
 				P\bigg\{ \sup\limits_{\vec w \in \Lambda}
-					{%\color{question2} 
+					{\color{question2} 
 						\Big|R_{(\vec w)} - R^{(p)}_{\text{emp}(\vec w)}\Big| 
 					} > \eta
 				\bigg\} < 4 \exp\Big( G^\Lambda_{(2p)} 

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -80,19 +80,19 @@ It is closely related to the \emph{VC dimension}.
 			y_{(\vec{x}^{(p)}, \vec{w})} \Big)$
 			\begin{itemize}	
 				\item different classifiers can induce the 
-					same label vector on the training set\notesonly{ (cf. \figref{fig:dichotomy_redundant})}
+					same label vector on the training set
+                    \notesonly{(cf. \figref{fig:dichotomy_redundant})
 					
-				%\begin{center}
-					%\includegraphics<2>[width=0.25\textwidth]{img/dichotomy_redundant}
-					%\notesonly{
-					%\captionof{figure}{Different weight vectors that produce identical labelng of the points.}
-					%}
-					%\label{fig:dichotomy_redundant}
-				%\end{center}
+				\begin{center}
+					\includegraphics[width=0.25\textwidth]{img/dichotomy_redundant}
+					\captionof{figure}{Different weight vectors that produce identical labelng of the points.}
+					\label{fig:dichotomy_redundant}
+				\end{center}
+                }
 			\end{itemize}
 			
 			Each classifier in $\Lambda$ describes a different hyperplane.
-            \mode<article>{
+            \notesonly{
 			Looking at the predictions each one produces for the $p$ points will produce some label vector $\vec y_{(\vec{w})}$ with $p$ elements. A prediction for every point.
 			}
 		\vspace{5mm}

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -259,7 +259,7 @@ It is closely related to the \emph{VC dimension}.
 \begin{frame}
 However, for $p > \dvc$ the growth function behaves differently, namely
 	\begin{equation}
-		G^{\Lambda}_{(p)} \le \dvc (1+ ln \frac{p}{\dvc}
+		G^{\Lambda}_{(p)} \le \dvc \cdot \big(1+ ln \frac{p}{\dvc}\big)
 	\end{equation}
 	
 	In this case  $\lim_{p \to \infty} G_{(p)}^\Lambda$ converges to zero, and there is no more complete ambiguity. There is at least one region in feature space where all different classifiers from $\Lambda$ will agree on what class to assign to points in that region. There may still exist regions for which predictions will be ambiguous but the complete ambiguity is gone. The more points we add, the less likely a model will find a solution, but if it does, they will no longer be ambiguous.

--- a/notes/09_slt/2_growth.tex
+++ b/notes/09_slt/2_growth.tex
@@ -336,7 +336,7 @@ However, for $p > \dvc$ the growth function behaves differently, namely
 						\Big|R_{(\vec w_p)} - R_{(\vec w_0)}\Big| 
 					}
 				\geq \eta \bigg\}\;\;=\;\; 0 \,, \quad \forall \eta > 0
-				\label{eq:risktozero}
+				%\label{eq:risktozero}
 			\end{equation}
 			
 			\textbf{But} Our dataset is never going to be infinitely large. Therefore, a more realistic formulation would be that ERM converges to some small $\epsilon$.\\

--- a/notes/09_slt/bibliography.bib
+++ b/notes/09_slt/bibliography.bib
@@ -29,6 +29,5 @@ url = {http://papers.nips.cc/paper/506-principles-of-risk-minimization-for-learn
   number={5},
   pages={988--999},
   year={1999},
-  publisher={Citeseer},
-url = {https://www.math.arizona.edu/~hzhang/math574m/Read/vapnik.pdf}
+  publisher={Citeseer}}
 }


### PR DESCRIPTION
mostly aesthetic and layout fixes:

- equation and figure references due to duplicate labels
- removed broken links in bib
- removed slides-only content from notes
- consistent dvc spelling
- parenthesis fixes and multiplication sign to avoid confusion with function parentheses.